### PR TITLE
feat(agents): align finding severity to blocker/warning/suggestion

### DIFF
--- a/agent_sdlc/agents/issue_refinement.py
+++ b/agent_sdlc/agents/issue_refinement.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
-from typing import List, Optional
+
+from typing import List
+
 from pydantic import BaseModel
 
-from agent_sdlc.core.findings import Finding
+from agent_sdlc.core.findings import Finding, FindingSeverity, parse_findings_from_json
 from agent_sdlc.core.llm_wrapper import LLMWrapper
 from agent_sdlc.core.providers import ProviderProtocol
 
@@ -13,33 +15,60 @@ class IssueInput(BaseModel):
 
 
 class IssueRefinementResult(BaseModel):
-    suggestions: List[Finding]
+    findings: List[Finding]
+
+    @property
+    def ready(self) -> bool:
+        """True only when there are zero BLOCKER findings."""
+        return not any(f.severity == FindingSeverity.BLOCKER for f in self.findings)
+
+    @property
+    def blocker_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == FindingSeverity.BLOCKER)
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == FindingSeverity.WARNING)
+
+    @property
+    def suggestion_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == FindingSeverity.SUGGESTION)
 
 
 class IssueRefinementAgent:
-    """Agent that asks the LLM to refine an issue into structured suggestions.
+    """Issue refinement agent that checks Definition of Ready via LLM.
 
-    The agent expects a JSON array of Finding-like suggestions from the provider.
+    The agent expects the provider to return a JSON array matching the Finding
+    model (fields: location, severity, rule, message, suggestion).
+    Severity must be one of: blocker, warning, suggestion.
+
+    ready=True when no BLOCKER findings are present — safe to enter a sprint.
+    Testable offline via DummyLLMProvider with pre-canned JSON responses.
     """
 
-    def __init__(self, provider: ProviderProtocol):
+    def __init__(self, provider: ProviderProtocol) -> None:
         self.llm = LLMWrapper(provider)
 
     def run(self, inp: IssueInput) -> IssueRefinementResult:
         prompt = (
-            f"Refine the issue titled '{inp.title}'. Return a JSON array of suggestions "
-            f"(id,title,description,severity,tags).\nDESCRIPTION:\n{inp.description}\n"
+            f"Check this issue's Definition of Ready.\n"
+            f"Issue title: '{inp.title}'\n"
+            f"Return a JSON array of findings. Each item must have:\n"
+            f"  location (str, e.g. 'body', 'title', 'labels'),\n"
+            f"  severity (blocker|warning|suggestion),\n"
+            f"  rule (str, e.g. 'DoR:ac-count'), message (str), suggestion (str or null).\n"
+            f"Return [] if the issue is ready.\n"
+            f"DESCRIPTION:\n{inp.description}\n"
         )
         text = self.llm.ask_text(prompt)
-        # parse JSON in a way that's compatible with pydantic v1 and v2
-        from agent_sdlc.core.findings import parse_findings_from_json
+        findings = parse_findings_from_json(text)
+        _order = {
+            FindingSeverity.BLOCKER: 0,
+            FindingSeverity.WARNING: 1,
+            FindingSeverity.SUGGESTION: 2,
+        }
+        findings.sort(key=lambda f: _order[f.severity])
+        return IssueRefinementResult(findings=findings)
 
-        suggestions = parse_findings_from_json(text)
-        return IssueRefinementResult(suggestions=suggestions)
 
-
-__all__ = [
-    "IssueRefinementAgent",
-    "IssueInput",
-    "IssueRefinementResult",
-]
+__all__ = ["IssueRefinementAgent", "IssueInput", "IssueRefinementResult"]

--- a/agent_sdlc/agents/pr_review.py
+++ b/agent_sdlc/agents/pr_review.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
+
 from typing import List, Optional
+
 from pydantic import BaseModel
 
-from agent_sdlc.core.findings import Finding
+from agent_sdlc.core.findings import Finding, FindingSeverity, parse_findings_from_json
 from agent_sdlc.core.llm_wrapper import LLMWrapper
 from agent_sdlc.core.providers import ProviderProtocol
 
@@ -16,28 +18,55 @@ class PRReviewInput(BaseModel):
 class PRReviewResult(BaseModel):
     findings: List[Finding]
 
+    @property
+    def approved(self) -> bool:
+        """True only when there are zero BLOCKER findings."""
+        return not any(f.severity == FindingSeverity.BLOCKER for f in self.findings)
+
+    @property
+    def blocker_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == FindingSeverity.BLOCKER)
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == FindingSeverity.WARNING)
+
+    @property
+    def suggestion_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == FindingSeverity.SUGGESTION)
+
 
 class PRReviewAgent:
-    """Simple PR review agent that asks the LLM to return a JSON list of Findings.
+    """PR review agent that asks the LLM to return a JSON list of Findings.
 
-    This agent expects the provider to return a JSON array matching the `Finding` model.
-    The approach keeps the agent lightweight and easy to test with `DummyLLMProvider`.
+    The agent expects the provider to return a JSON array matching the Finding
+    model (fields: location, severity, rule, message, suggestion).
+    Severity must be one of: blocker, warning, suggestion.
+
+    Testable offline via DummyLLMProvider with pre-canned JSON responses.
     """
 
-    def __init__(self, provider: ProviderProtocol):
+    def __init__(self, provider: ProviderProtocol) -> None:
         self.llm = LLMWrapper(provider)
 
     def run(self, inp: PRReviewInput) -> PRReviewResult:
         prompt = (
             f"Review the following pull request titled '{inp.title}'.\n"
-            f"Return a JSON array of findings with fields (id,title,description,severity,tags).\n"
+            f"Return a JSON array of findings. Each item must have:\n"
+            f"  location (str), severity (blocker|warning|suggestion),\n"
+            f"  rule (str), message (str), suggestion (str or null).\n"
+            f"Exit 0 if no findings: return [].\n"
             f"DIFF:\n{inp.diff}\n"
         )
         text = self.llm.ask_text(prompt)
-        # parse JSON in a way that's compatible with pydantic v1 and v2
-        from agent_sdlc.core.findings import parse_findings_from_json
-
         findings = parse_findings_from_json(text)
+        # Sort: blockers first, then warnings, then suggestions
+        _order = {
+            FindingSeverity.BLOCKER: 0,
+            FindingSeverity.WARNING: 1,
+            FindingSeverity.SUGGESTION: 2,
+        }
+        findings.sort(key=lambda f: _order[f.severity])
         return PRReviewResult(findings=findings)
 
 

--- a/agent_sdlc/core/findings.py
+++ b/agent_sdlc/core/findings.py
@@ -1,67 +1,59 @@
+"""
+agent_sdlc/core/findings.py
+
+Shared finding types used by all review and quality-gate agents.
+
+Both the PR Review Agent and the Issue Refinement Agent produce findings
+using these types. Centralising them here avoids cross-agent imports and
+provides a consistent schema for any future lifecycle automation.
+
+Usage:
+    from agent_sdlc.core.findings import Finding, FindingSeverity
+"""
+
 from __future__ import annotations
+
 from enum import Enum
-from typing import List, Optional
-from pydantic import BaseModel, Field
-from typing import Any
+from typing import Optional, List
 import json
 
-# `parse_raw_as` existed in pydantic v1 but was removed in v2; import if available
-try:
-    from pydantic import parse_raw_as  # type: ignore
-except Exception:
-    parse_raw_as = None
+from pydantic import BaseModel, Field
 
 
-class Severity(str, Enum):
-    LOW = "LOW"
-    MEDIUM = "MEDIUM"
-    HIGH = "HIGH"
+class FindingSeverity(str, Enum):
+    BLOCKER = "blocker"     # Must be resolved before the gated action proceeds
+    WARNING = "warning"     # Should be addressed; reviewer judgment required
+    SUGGESTION = "suggestion"  # Optional improvement; low priority
 
 
 class Finding(BaseModel):
-    """A portable finding schema used by agents and tests.
+    """A portable finding schema used by review and quality-gate agents."""
 
-    This model includes the simple fields expected by the unit tests
-    (`id`, `title`, `description`, `severity`, `tags`) and a few optional
-    fields useful for richer integrations (`location`, `line_number`).
-    """
-
-    id: Optional[str] = None
-    title: str
-    description: str
-    severity: Severity = Severity.MEDIUM
-    tags: List[str] = Field(default_factory=list)
-
-    # Optional extras for richer consumers
-    location: Optional[str] = None
+    location: str = Field(
+        default="(unspecified)",
+        description="Where the finding applies: file path, field name, or '(diff line)'.",
+    )
     line_number: Optional[int] = None
+    severity: FindingSeverity = FindingSeverity.WARNING
+    rule: str = Field(
+        default="general",
+        description="Short rule identifier, e.g. 'code:type-hints', 'DoR:ac-count'.",
+    )
+    message: str
     suggestion: Optional[str] = None
 
 
-__all__ = ["Finding", "Severity"]
-
-
-def _make_finding(item: Any) -> Finding:
-    """Construct a `Finding` from a mapping, compatible with pydantic v1 and v2.
-
-    Usage: prefer `parse_raw_as(List[Finding], text)` for raw JSON, but fall back
-    to this helper when that isn't available or fails.
-    """
+def _make_finding(item: dict) -> Finding:
+    """Construct a Finding from a raw dict, compatible with pydantic v1 and v2."""
     if hasattr(Finding, "model_validate"):
         return Finding.model_validate(item)
-    return Finding.parse_obj(item)
+    return Finding.parse_obj(item)  # type: ignore[attr-defined]
 
 
-def parse_findings_from_json(text: str) -> list[Finding]:
-    """Parse a JSON array of findings into a list of `Finding` models.
-
-    Tries `pydantic.parse_raw_as(List[Finding], ...)` first for v1/v2 compatibility
-    and falls back to `json.loads` + `_make_finding` when needed.
-    """
-    if parse_raw_as is not None:
-        try:
-            return parse_raw_as(list[Finding], text)
-        except Exception:
-            pass
+def parse_findings_from_json(text: str) -> List[Finding]:
+    """Parse a JSON array of findings into a list of Finding models."""
     payload = json.loads(text)
     return [_make_finding(item) for item in payload]
+
+
+__all__ = ["Finding", "FindingSeverity", "parse_findings_from_json"]

--- a/scripts/run_issue_refinement.py
+++ b/scripts/run_issue_refinement.py
@@ -1,19 +1,151 @@
-"""Simple runner for the Issue Refinement agent (local/demo only).
+"""Runner for the Issue Refinement Agent (Definition of Ready check).
 
-Usage: python scripts/run_issue_refinement.py
+Local demo (DummyLLMProvider):
+    python scripts/run_issue_refinement.py
+
+CI / production (requires ANTHROPIC_API_KEY and gh CLI):
+    python scripts/run_issue_refinement.py --issue 8 --post-comment --update-labels
+
+Exits 0 if DoR passes (ready=True); exits 1 if any BLOCKER findings exist.
 """
-from agent_sdlc.agents.issue_refinement import IssueRefinementAgent, IssueInput
-from agent_sdlc.core.providers import DummyLLMProvider
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+from datetime import datetime
+
+from agent_sdlc.agents.issue_refinement import IssueInput, IssueRefinementAgent
+from agent_sdlc.core.findings import FindingSeverity
+from agent_sdlc.core.providers import DummyLLMProvider, ProviderProtocol
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s — %(message)s")
+logger = logging.getLogger(__name__)
+
+_SEVERITY_SYMBOL = {
+    FindingSeverity.BLOCKER: "BLOCKER",
+    FindingSeverity.WARNING: "WARNING",
+    FindingSeverity.SUGGESTION: "SUGGESTION",
+}
 
 
-def main() -> None:
-    demo_response = '[{"id":"s1","title":"Add repro steps","description":"Ask for minimal repro steps","severity":"LOW","tags":["process"]}]'
-    provider = DummyLLMProvider(default=demo_response)
+def _run(cmd: list[str], check: bool = True) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True, check=check)
+    return result.stdout.strip()
+
+
+def _fetch_issue(issue_number: int) -> IssueInput:
+    logger.info("Fetching issue #%d via gh CLI...", issue_number)
+    meta_json = _run([
+        "gh", "issue", "view", str(issue_number),
+        "--json", "number,title,body,labels,milestone,assignees,state",
+    ])
+    meta = json.loads(meta_json)
+    return IssueInput(
+        title=meta["title"],
+        description=meta.get("body") or "",
+    )
+
+
+def _build_provider() -> ProviderProtocol:
+    import os
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        try:
+            from agent_sdlc.core.anthropic_provider import AnthropicProvider
+            return AnthropicProvider()
+        except Exception as exc:
+            logger.warning("Could not load AnthropicProvider (%s) — using DummyLLMProvider.", exc)
+    return DummyLLMProvider(default="[]")
+
+
+def _print_result(result, issue_number: int | None = None) -> None:
+    label = f"Issue #{issue_number}" if issue_number else "Demo Issue"
+    print("\n" + "=" * 70)
+    print(f"{label} DoR Check — {datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}")
+    print(f"Status: {'READY' if result.ready else 'NOT READY'}")
+    print(f"Findings: {result.blocker_count} blocker(s), {result.warning_count} warning(s), "
+          f"{result.suggestion_count} suggestion(s)")
+    print("=" * 70)
+    for f in result.findings:
+        sym = _SEVERITY_SYMBOL[f.severity]
+        print(f"  [{sym}] {f.rule} @ {f.location}")
+        print(f"     {f.message}")
+        if f.suggestion:
+            print(f"     → {f.suggestion}")
+    if not result.findings:
+        print("  No findings — issue is DoR ready.")
+    print("=" * 70 + "\n")
+
+
+def _post_comment(issue_number: int, result) -> None:
+    status = (
+        "**Status: DoR passed — eligible for sprint planning (human approval required)**"
+        if result.ready
+        else "**Status: NOT READY — blockers must be resolved before sprint entry**"
+    )
+    lines = [f"## Issue Refinement Agent (DoR Check)\n\n{status}\n"]
+    if result.findings:
+        lines.append("| Severity | Location | Rule | Message |")
+        lines.append("|----------|----------|------|---------|")
+        for f in result.findings:
+            msg = f.message.replace("|", "\\|")
+            lines.append(f"| {f.severity.value} | `{f.location}` | `{f.rule}` | {msg} |")
+    else:
+        lines.append("_No findings._")
+    body = "\n".join(lines)
+    _run(["gh", "issue", "comment", str(issue_number), "--body", body])
+    logger.info("Comment posted to issue #%d.", issue_number)
+
+
+def _update_labels(issue_number: int, ready: bool) -> None:
+    if ready:
+        _run(["gh", "issue", "edit", str(issue_number), "--remove-label", "needs-review"], check=False)
+    else:
+        _run(["gh", "issue", "edit", str(issue_number), "--add-label", "blocked"], check=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the Issue Refinement Agent (DoR check).")
+    parser.add_argument("--issue", type=int, metavar="NUMBER", help="GitHub issue number")
+    parser.add_argument("--post-comment", action="store_true")
+    parser.add_argument("--update-labels", action="store_true")
+    args = parser.parse_args()
+
+    if args.issue:
+        try:
+            inp = _fetch_issue(args.issue)
+        except Exception as exc:
+            logger.error("Failed to fetch issue #%d: %s", args.issue, exc)
+            return 1
+    else:
+        # Local demo mode
+        inp = IssueInput(
+            title="Demo: Add retry logic",
+            description="Something is broken — needs investigation.",
+        )
+
+    provider = _build_provider()
     agent = IssueRefinementAgent(provider)
-    inp = IssueInput(title="Bug: crash on save", description="App crashes when saving a file under certain conditions")
-    out = agent.run(inp)
-    print(out.json(indent=2))
+    result = agent.run(inp)
+    _print_result(result, args.issue)
+
+    if args.issue and args.post_comment:
+        try:
+            _post_comment(args.issue, result)
+        except Exception as exc:
+            logger.error("Failed to post comment: %s", exc)
+
+    if args.issue and args.update_labels:
+        try:
+            _update_labels(args.issue, result.ready)
+        except Exception as exc:
+            logger.error("Failed to update labels: %s", exc)
+
+    return 0 if result.ready else 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/run_pr_review.py
+++ b/scripts/run_pr_review.py
@@ -1,20 +1,145 @@
-"""Simple runner for the PR review agent (local/demo only).
+"""Runner for the PR Review Agent.
 
-Usage: python scripts/run_pr_review.py
+Local demo (DummyLLMProvider):
+    python scripts/run_pr_review.py
+
+CI / production (requires ANTHROPIC_API_KEY and gh CLI):
+    python scripts/run_pr_review.py --pr 42 --post-comment
+
+Exits 0 if no BLOCKER findings; exits 1 if any BLOCKERs exist.
 """
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+from datetime import datetime
+
 from agent_sdlc.agents.pr_review import PRReviewAgent, PRReviewInput
-from agent_sdlc.core.providers import DummyLLMProvider
+from agent_sdlc.core.findings import FindingSeverity
+from agent_sdlc.core.providers import DummyLLMProvider, ProviderProtocol
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s — %(message)s")
+logger = logging.getLogger(__name__)
+
+_SEVERITY_SYMBOL = {
+    FindingSeverity.BLOCKER: "BLOCKER",
+    FindingSeverity.WARNING: "WARNING",
+    FindingSeverity.SUGGESTION: "SUGGESTION",
+}
 
 
-def main() -> None:
-    # Demo response: a JSON array acceptable to the PRReviewAgent
-    demo_response = '[{"id":"1","title":"Use f-strings","description":"old-style formatting detected","severity":"LOW","tags":["style"]}]'
-    provider = DummyLLMProvider(default=demo_response)
+def _run(cmd: list[str], check: bool = True) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True, check=check)
+    return result.stdout.strip()
+
+
+def _fetch_pr(pr_number: int) -> PRReviewInput:
+    logger.info("Fetching PR #%d via gh CLI...", pr_number)
+    meta_json = _run([
+        "gh", "pr", "view", str(pr_number),
+        "--json", "number,title,body,baseRefName,headRefName,author,files",
+    ])
+    meta = json.loads(meta_json)
+    try:
+        diff = _run(["gh", "pr", "diff", str(pr_number)])
+    except subprocess.CalledProcessError:
+        logger.warning("Could not fetch diff for PR #%d — proceeding without it.", pr_number)
+        diff = ""
+    return PRReviewInput(
+        title=meta["title"],
+        diff=diff,
+        author=meta["author"]["login"],
+    )
+
+
+def _build_provider() -> ProviderProtocol:
+    """Return a real provider if credentials are available, else DummyLLMProvider."""
+    import os
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        try:
+            from agent_sdlc.core.anthropic_provider import AnthropicProvider
+            return AnthropicProvider()
+        except Exception as exc:
+            logger.warning("Could not load AnthropicProvider (%s) — using DummyLLMProvider.", exc)
+    return DummyLLMProvider(default="[]")
+
+
+def _print_result(result) -> None:
+    print("\n" + "=" * 70)
+    print(f"PR Review — {datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}")
+    print(f"Status: {'APPROVED (no blockers)' if result.approved else 'BLOCKED'}")
+    print(f"Findings: {result.blocker_count} blocker(s), {result.warning_count} warning(s), "
+          f"{result.suggestion_count} suggestion(s)")
+    print("=" * 70)
+    for f in result.findings:
+        sym = _SEVERITY_SYMBOL[f.severity]
+        loc = f.location + (f":{f.line_number}" if f.line_number else "")
+        print(f"  [{sym}] {f.rule} @ {loc}")
+        print(f"     {f.message}")
+        if f.suggestion:
+            print(f"     → {f.suggestion}")
+    if not result.findings:
+        print("  No findings.")
+    print("=" * 70 + "\n")
+
+
+def _post_comment(pr_number: int, result) -> None:
+    status = (
+        "**Status: No blockers — eligible for merge (human approval required)**"
+        if result.approved
+        else "**Status: BLOCKED — blockers must be resolved before merge**"
+    )
+    lines = [f"## PR Review Agent\n\n{status}\n"]
+    if result.findings:
+        lines.append("| Severity | Location | Rule | Message |")
+        lines.append("|----------|----------|------|---------|")
+        for f in result.findings:
+            loc = f.location + (f":{f.line_number}" if f.line_number else "")
+            msg = f.message.replace("|", "\\|")
+            lines.append(f"| {f.severity.value} | `{loc}` | `{f.rule}` | {msg} |")
+    else:
+        lines.append("_No findings._")
+    body = "\n".join(lines)
+    _run(["gh", "pr", "comment", str(pr_number), "--body", body])
+    logger.info("Comment posted to PR #%d.", pr_number)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the PR Review Agent.")
+    parser.add_argument("--pr", type=int, metavar="NUMBER", help="GitHub PR number")
+    parser.add_argument("--post-comment", action="store_true")
+    args = parser.parse_args()
+
+    if args.pr:
+        try:
+            inp = _fetch_pr(args.pr)
+        except Exception as exc:
+            logger.error("Failed to fetch PR #%d: %s", args.pr, exc)
+            return 1
+    else:
+        # Local demo mode
+        inp = PRReviewInput(
+            title="Demo PR",
+            diff='+ import anthropic\n+ def foo(): pass',
+        )
+
+    provider = _build_provider()
     agent = PRReviewAgent(provider)
-    inp = PRReviewInput(title="Example PR", diff="- x = '%s' % name\n+ x = f'{name}'")
-    out = agent.run(inp)
-    print(out.json(indent=2))
+    result = agent.run(inp)
+    _print_result(result)
+
+    if args.pr and args.post_comment:
+        try:
+            _post_comment(args.pr, result)
+        except Exception as exc:
+            logger.error("Failed to post comment: %s", exc)
+
+    return 0 if result.approved else 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_issue_refinement_agent.py
+++ b/tests/test_issue_refinement_agent.py
@@ -1,13 +1,57 @@
 from agent_sdlc.agents.issue_refinement import IssueRefinementAgent, IssueInput
+from agent_sdlc.core.findings import FindingSeverity
 from agent_sdlc.core.providers import DummyLLMProvider
 
 
+def test_issue_refinement_ready_when_no_findings():
+    provider = DummyLLMProvider(default="[]")
+    agent = IssueRefinementAgent(provider)
+    inp = IssueInput(title="Add retry logic", description="- [ ] impl\n- [ ] test\n- [ ] docs")
+    res = agent.run(inp)
+    assert res.findings == []
+    assert res.ready is True
+    assert res.blocker_count == 0
+
+
 def test_issue_refinement_parses_suggestions():
-    sample = '[{"id":"s1","title":"Add repro steps","description":"Provide steps to reproduce","severity":"LOW","tags":["process"]}]'
+    sample = (
+        '[{"location":"body","severity":"suggestion","rule":"DoR:ac-clarity",'
+        '"message":"AC item is vague","suggestion":"Make it testable"}]'
+    )
     provider = DummyLLMProvider(default=sample)
     agent = IssueRefinementAgent(provider)
     inp = IssueInput(title="Crash on save", description="Crashes when saving large files")
     res = agent.run(inp)
-    assert len(res.suggestions) == 1
-    s = res.suggestions[0]
-    assert s.title == "Add repro steps"
+    assert len(res.findings) == 1
+    f = res.findings[0]
+    assert f.severity == FindingSeverity.SUGGESTION
+    assert f.rule == "DoR:ac-clarity"
+    assert res.ready is True  # suggestions don't block
+
+
+def test_issue_refinement_blocker_not_ready():
+    sample = (
+        '[{"location":"body","severity":"blocker","rule":"DoR:ac-count",'
+        '"message":"Fewer than 3 AC checkboxes found","suggestion":"Add more - [ ] items"}]'
+    )
+    provider = DummyLLMProvider(default=sample)
+    agent = IssueRefinementAgent(provider)
+    inp = IssueInput(title="Vague issue", description="Something is broken")
+    res = agent.run(inp)
+    assert res.ready is False
+    assert res.blocker_count == 1
+
+
+def test_issue_refinement_findings_sorted_blockers_first():
+    sample = (
+        '['
+        '{"location":"labels","severity":"warning","rule":"DoR:label-type","message":"No type label"},'
+        '{"location":"body","severity":"blocker","rule":"DoR:ac-count","message":"No AC items"}'
+        ']'
+    )
+    provider = DummyLLMProvider(default=sample)
+    agent = IssueRefinementAgent(provider)
+    inp = IssueInput(title="Issue", description="desc")
+    res = agent.run(inp)
+    assert res.findings[0].severity == FindingSeverity.BLOCKER
+    assert res.findings[1].severity == FindingSeverity.WARNING

--- a/tests/test_pr_review_agent.py
+++ b/tests/test_pr_review_agent.py
@@ -1,14 +1,59 @@
 from agent_sdlc.agents.pr_review import PRReviewAgent, PRReviewInput
+from agent_sdlc.core.findings import FindingSeverity
 from agent_sdlc.core.providers import DummyLLMProvider
 
 
+def test_pr_review_no_findings():
+    provider = DummyLLMProvider(default="[]")
+    agent = PRReviewAgent(provider)
+    inp = PRReviewInput(title="Clean PR", diff="+ pass")
+    res = agent.run(inp)
+    assert res.findings == []
+    assert res.approved is True
+    assert res.blocker_count == 0
+
+
 def test_pr_review_agent_parses_findings():
-    sample = '[{"id":"1","title":"Use f-strings","description":"old-style formatting detected","severity":"LOW","tags":["style"]}]'
+    sample = (
+        '[{"location":"src/foo.py","severity":"warning","rule":"code:type-hints",'
+        '"message":"Missing return type hint","suggestion":"Add -> None"}]'
+    )
     provider = DummyLLMProvider(default=sample)
     agent = PRReviewAgent(provider)
-    inp = PRReviewInput(title="Add foo", diff="- x = '%s' % name\n+ x = f'{name}'")
+    inp = PRReviewInput(title="Add foo", diff="+ def bar(): pass")
     res = agent.run(inp)
     assert len(res.findings) == 1
     f = res.findings[0]
-    assert f.title == "Use f-strings"
-    assert f.severity.value == "LOW"
+    assert f.severity == FindingSeverity.WARNING
+    assert f.rule == "code:type-hints"
+    assert res.approved is True  # no blockers
+    assert res.warning_count == 1
+
+
+def test_pr_review_blocker_fails_approval():
+    sample = (
+        '[{"location":"agent_sdlc/agents/foo.py","severity":"blocker",'
+        '"rule":"code:no-direct-sdk","message":"Direct anthropic import detected",'
+        '"suggestion":"Use ProviderProtocol instead"}]'
+    )
+    provider = DummyLLMProvider(default=sample)
+    agent = PRReviewAgent(provider)
+    inp = PRReviewInput(title="Bad PR", diff="+ import anthropic")
+    res = agent.run(inp)
+    assert res.approved is False
+    assert res.blocker_count == 1
+
+
+def test_pr_review_findings_sorted_blockers_first():
+    sample = (
+        '['
+        '{"location":"a.py","severity":"suggestion","rule":"style","message":"minor"},'
+        '{"location":"b.py","severity":"blocker","rule":"code:no-direct-sdk","message":"critical"}'
+        ']'
+    )
+    provider = DummyLLMProvider(default=sample)
+    agent = PRReviewAgent(provider)
+    inp = PRReviewInput(title="Mixed", diff="+ x = 1")
+    res = agent.run(inp)
+    assert res.findings[0].severity == FindingSeverity.BLOCKER
+    assert res.findings[1].severity == FindingSeverity.SUGGESTION


### PR DESCRIPTION
## Summary

- Renamed `Severity(LOW/MEDIUM/HIGH)` → `FindingSeverity(blocker/warning/suggestion)` in `findings.py` to match the SDLC intent from CLAUDE.md and the golden_boy pattern
- `PRReviewResult.approved` and `IssueRefinementResult.ready` now gate on zero BLOCKER findings
- Runner scripts (`run_pr_review.py`, `run_issue_refinement.py`) exit 1 on any BLOCKER, enabling CI gating
- LLM prompts updated to instruct `blocker|warning|suggestion` severity values
- Findings sorted blockers-first in both agents
- All 13 tests pass; 4 skipped (Postgres e2e + optional SDK installs)

## Test plan

- [x] `pytest -q` — 13 passed, 4 skipped
- [x] `test_pr_review_blocker_fails_approval` — approved=False on BLOCKER
- [x] `test_issue_refinement_blocker_not_ready` — ready=False on BLOCKER
- [x] `test_pr_review_findings_sorted_blockers_first` — sort order verified
- [x] `test_issue_refinement_findings_sorted_blockers_first` — sort order verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)